### PR TITLE
Add some user docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /node_modules/
+/docs/build/
+/docs/_build/
+.ropeproject/
+*.pyc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 /dist/*
+/docs/build/
+/docs/_build/
+/docs/_static/ethicalads.js

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/docs.css
+++ b/docs/_static/docs.css
@@ -1,0 +1,30 @@
+.container {
+    padding-top: 1em;
+    padding-bottom: 1em;
+}
+
+.container.row {
+    display: flex;
+    margin-bottom: 1em;
+}
+
+.container.dark {
+    background: #443;
+}
+
+.container.row .container.column {
+    text-align: center;
+    flex: 1;
+}
+
+.container.row .container.left {
+    flex: 3;
+}
+.container.row .container.right {
+    flex: 2;
+    text-align: right;
+}
+
+.container.row .container.column p:first-child {
+    margin-bottom: 0.25em;
+}

--- a/docs/_static/docs.css
+++ b/docs/_static/docs.css
@@ -1,30 +1,30 @@
 .container {
-    padding-top: 1em;
-    padding-bottom: 1em;
+  padding-top: 1em;
+  padding-bottom: 1em;
 }
 
 .container.row {
-    display: flex;
-    margin-bottom: 1em;
+  display: flex;
+  margin-bottom: 1em;
 }
 
 .container.dark {
-    background: #443;
+  background: #443;
 }
 
 .container.row .container.column {
-    text-align: center;
-    flex: 1;
+  text-align: center;
+  flex: 1;
 }
 
 .container.row .container.left {
-    flex: 3;
+  flex: 3;
 }
 .container.row .container.right {
-    flex: 2;
-    text-align: right;
+  flex: 2;
+  text-align: right;
 }
 
 .container.row .container.column p:first-child {
-    margin-bottom: 0.25em;
+  margin-bottom: 0.25em;
 }

--- a/docs/_static/ethicalads.js
+++ b/docs/_static/ethicalads.js
@@ -1,0 +1,1 @@
+../../dist/ethicalads.js

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import re
+import json
+from pathlib import Path
+
+from docutils.parsers.rst import Directive
+from docutils import nodes
+
+path_pkg_config = Path('../package.json');
+pkg_config = json.load(path_pkg_config.open())
+
+project = pkg_config.get('description')
+slug = pkg_config.get('name')
+version = pkg_config.get('version')
+release = version
+author = pkg_config.get('author')
+copyright = author
+language = 'en'
+
+extensions = [
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+source_suffix = '.rst'
+exclude_patterns = [
+    '.ropeproject/',
+    '_build',
+    'conf.py~',
+]
+locale_dirs = ['locale/']
+gettext_compact = False
+
+master_doc = 'index'
+pygments_style = 'default'
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_options = {}
+html_static_path = ['_static']
+html_context = {}
+html_js_files = [
+    'ethicalads.js',
+]
+html_css_files = [
+    'docs.css',
+]
+html_show_sourcelink = True
+
+htmlhelp_basename = slug
+
+latex_documents = [
+  ('index', '{0}.tex'.format(slug), project, author, 'manual'),
+]
+
+man_pages = [
+    ('index', slug, project, [author], 1)
+]
+
+texinfo_documents = [
+  ('index', slug, project, author, slug, project, 'Miscellaneous'),
+]
+
+
+class ExampleDirective(Directive):
+
+    templates = {
+        'image': """
+<div class="loaded {classes}" data-ea-type="image">
+  <div class="ea-content">
+    <a href="#" rel="nofollow" target="_blank">
+      <img src="https://via.placeholder.com/240x180.png" />
+    </a>
+    <div class="ea-text">
+      <a href="#" rel="nofollow" target="_blank">
+        <strong>EthicalAds</strong> is a developer-focused, privacy-obsessed ad
+        network from the fine folks at Read the Docs
+      </a>
+    </div>
+  </div>
+  <div class="ea-callout">
+    <a href="https://ethicalads.io/">Ad by EthicalAds</a>
+  </div>
+</div>
+        """,
+        'text': """
+<div class="loaded {classes}" data-ea-type="text">
+  <div class="ea-content">
+    <div class="ea-text">
+      <a href="#" rel="nofollow" target="_blank">
+        <strong>EthicalAds</strong> is a developer-focused, privacy-obsessed ad
+        network from the fine folks at Read the Docs
+      </a>
+    </div>
+  </div>
+  <div class="ea-callout">
+    <a href="https://ethicalads.io/">Ad by EthicalAds</a>
+  </div>
+</div>
+        """,
+    }
+
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        'classes': str,
+        'ad_type': str,
+    }
+    has_content = True
+
+    def run(self):
+        ad_type = self.options.get('ad_type', 'image')
+        attributes = {
+            "classes": self.options.get('classes', 'raised'),
+            "ad_type": ad_type,
+        }
+        text = self.templates.get(ad_type, "").format(**attributes)
+        node = nodes.raw('', text, format='html')
+        (node.source, node.line) = self.state_machine.get_source_and_line(self.lineno)
+        return [node]
+
+
+def setup(app):
+    app.add_directive('example', ExampleDirective)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,210 @@
+EthicalAds Client
+=================
+
+This is the client library used to add an ad placement from EthicalAds_ to your
+site. To get started, you will need to first :ref:`become a publisher <signup>`,
+and then you can :ref:`configure your site <Configuration>`.
+
+Usage
+=====
+
+There are two pieces required to add an ad placement to your site. You will need
+to create an empty ``<div>`` element where you would like to place a new ad
+placement, and you will need to include the client library.
+
+To start, add the following in your site's ``<head>``:
+
+.. code:: html
+
+    <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
+
+To add the placement on your site, you will need to add an empty ``<div>`` with
+some added data attributes to configure the ad placement:
+
+.. code:: html
+
+    <div data-ea-publisher="..." data-ea-type="text"></div>
+
+.. _configuration:
+
+Configuration
+=============
+
+The following data attributes are supported on the ad placement element:
+
+``data-ea-publisher``
+    **(Required)** The EthicalAds publisher id for your account.
+
+``data-ea-type``
+    The ad placement type. This value can be either ``image`` or ``text`` -- the
+    default is ``image``.
+
+Themes
+======
+
+The following themes are available on all ad placement types:
+
+.. container:: row
+
+    .. container:: left
+
+        **Raised theme**
+
+        This is the default theme used if you do not specify a theme.
+
+        .. code:: html
+
+            <div data-ea-publisher="..."></div>
+
+        Or you can also explicitly use the theme name:
+
+        .. code:: html
+
+            <div class="raised" data-ea-publisher="..."></div>
+
+
+    .. container:: right
+
+        .. example::
+            :ad_type: image
+            :classes: raised
+
+.. container:: row
+
+    .. container:: left
+
+        **Flat theme**
+
+        .. code:: html
+
+            <div class="flat" data-ea-publisher="..."></div>
+
+    .. container:: right
+
+        .. example::
+            :ad_type: image
+            :classes: flat
+
+.. container:: row
+
+    .. container:: left
+
+        **Bordered theme**
+
+        .. code:: html
+
+            <div class="borderd" data-ea-publisher="..."></div>
+
+    .. container:: right
+
+        .. example::
+            :ad_type: image
+            :classes: bordered
+
+There are also dark variants for all of the themes. The dark variants can be
+used with the ``dark`` class:
+
+.. code:: html
+
+    <div class="dark raised" data-ea-publisher="..."></div>
+
+.. container:: row dark
+
+    .. container:: column
+
+        .. example::
+            :ad_type: image
+            :classes: dark raised
+
+    .. container:: column
+
+        .. example::
+            :ad_type: image
+            :classes: dark flat
+
+    .. container:: column
+
+        .. example::
+            :ad_type: image
+            :classes: dark bordered
+
+Ad Types
+========
+
+Image placement
+---------------
+
+The image ad placement type has two variants: horizontal and veritcal. Vertical
+image placements are the default ad type. To use the horizontal variant, use
+
+**Vertical image**
+
+.. code:: html
+
+    <div data-ea-publisher="..." data-ad-type="image"></div>
+
+
+.. container:: row
+
+    .. container:: column
+
+        .. example::
+            :ad_type: image
+            :classes: raised
+
+    .. container:: dark column
+
+        .. example::
+            :ad_type: image
+            :classes: dark raised
+
+
+**Horizontal image**
+
+This variant can be used with the ``horizontal`` theme variant class:
+
+.. code:: html
+
+    <div class="horizontal" data-ea-publisher="..." data-ad-type="image"></div>
+
+.. container:: row
+
+    .. container:: column
+
+        .. example::
+            :ad_type: image
+            :classes: horizontal raised
+
+    .. container:: dark column
+
+        .. example::
+            :ad_type: image
+            :classes: dark horizontal raised
+
+Text placement
+--------------
+
+Text placements can be defined using ``data-ad-type="text"``:
+
+.. code:: html
+
+    <div data-ea-publisher="..." data-ad-type="text"></div>
+
+.. example::
+    :ad_type: text
+    :classes: raised
+
+.. container:: row dark
+
+    .. example::
+        :ad_type: text
+        :classes: dark raised
+
+.. _signup:
+
+Becoming a Publisher
+====================
+
+Visit `EthicalAds`_ to apply to be a publisher.
+
+.. _`EthicalAds`: https://ethicalads.io

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethical-ad-client",
   "version": "1.0.0",
-  "description": "Ethical Ads client",
+  "description": "EthicalAds client",
   "main": "dist/client.js",
   "scripts": {
     "build": "npm ci && npm run build-min && npm run build-unmin",


### PR DESCRIPTION
This adds some docs that touchs on the ad placement types and the ad
placement themes. It actually uses the underlying `dist/ethicalads.js`,
so it's even possible to use this to review changes to the ad placement
styles in our PR builder :tada:

I absolutely phoned it in on the publisher sign up section. Let's add
some copy there.