### PR TITLE
Add keywords and campaign types to the client

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,15 @@ The following data attributes are supported on the ad placement element:
     The ad placement type. This value can be either ``image`` or ``text`` -- the
     default is ``image``.
 
+``data-ea-keywords`` (optional)
+    A pipe (``|``) separated array of keywords for this ad placement.
+    This is page-specific (not publisher-specific) keywords related to where the ad is shown.
+
+``data-ea-campaign-types`` (optional)
+    A pipe (``|``) separated array of campaign types ("paid", "community", "house").
+    This can only further reduce campaign types, not allow ones prohibited for the publisher.
+    This is useful when you want certain users to not get certain types of ads.
+
 Themes
 ------
 

--- a/index.js
+++ b/index.js
@@ -42,12 +42,17 @@ const SUPPORTS_MULTIPLE_PLACEMENTS = false;
  * @param {string} publisher - Publisher ID
  * @param {string} ad_type - Placement ad type id
  * @param {Element} target - Target element
+ * @param {string} keywords - An optional | separated array of keywords
+ * @param {string} campaign_types - An optional | separated array of campaign types
  */
 export class Placement {
-  constructor(publisher, ad_type = "image", target) {
+  constructor(publisher, ad_type = "image", target, keywords, campaign_types) {
     this.publisher = publisher;
     this.ad_type = ad_type;
     this.target = target;
+
+    this.keywords = keywords || "";
+    this.campaign_types = campaign_types || "paid|community|house";
   }
 
   /* Create a placement from an element
@@ -65,10 +70,15 @@ export class Placement {
       element.setAttribute(ATTR_PREFIX + "type", "image");
     }
 
-    // Add version to ad type to verison the HTML return
-    ad_type += "-v" + AD_CLIENT_VERSION;
+    const keywords = element.getAttribute(ATTR_PREFIX + "keywords");
+    const campaign_types = element.getAttribute(ATTR_PREFIX + "campaign-types");
 
-    return new Placement(publisher, ad_type, element);
+    // Add version to ad type to verison the HTML return
+    if (ad_type === "image" || ad_type === "text") {
+      ad_type += "-v" + AD_CLIENT_VERSION;
+    }
+
+    return new Placement(publisher, ad_type, element, keywords, campaign_types);
   }
 
   /* Transforms target element into a placement
@@ -116,6 +126,8 @@ export class Placement {
       publisher: this.publisher,
       ad_types: this.ad_type,
       div_ids: id,
+      keywords: this.keywords,
+      campaign_types: this.campaign_types,
       callback: id,
       format: "jsonp",
     });


### PR DESCRIPTION
Allow publishers to optionally limit campaign types or to include keywords with their ad request.

```html
<div data-ea-publisher="ethicaladsio" data-ea-type="image" data-ea-campaign-types="paid|house" data-ea-keywords="bitcoin|ethereum"></div>
```