### PR TITLE
Include client version in ad decision

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -370,3 +370,30 @@ Becoming a Publisher
 Visit `EthicalAds`_ to apply to be a publisher.
 
 .. _`EthicalAds`: https://ethicalads.io
+
+
+Developing
+----------
+
+This section is for developers of the client itself.
+Development occurs on `GitHub <https://github.com/readthedocs/ethical-ad-client>`_.
+
+* `Issues <https://github.com/readthedocs/ethical-ad-client/issues>`_
+* `Pull requests <https://github.com/readthedocs/ethical-ad-client/pulls>`_
+
+
+Releasing
+~~~~~~~~~
+
+This is the release process for the client itself.
+
+* First update the version in ``package.json`` **and** ``index.js``.
+  The versions use `semantic versioning <https://semver.org/>`_.
+* Run ``npm install && npm run build``.
+  This ensures you have the latest dependencies and you've built
+  the latest version of the documentation.
+* Release the `beta client`_ and purge the client from the CDN.
+* Release the `release client`_ and purge the CDN.
+
+.. _beta client: https://media.ethicalads.io/media/client/beta/ethicalads.min.js
+.. _release client: https://media.ethicalads.io/media/client/ethicalads.min.js

--- a/index.js
+++ b/index.js
@@ -29,10 +29,13 @@ import verge from "verge";
 
 import "./styles.scss";
 
+
+const AD_CLIENT_VERSION = "1.1.0";  // Sent with the ad request
+
+
 // For local testing, set this
 // const AD_DECISION_URL = "http://ethicaladserver:5000/api/v1/decision/";
 const AD_DECISION_URL = "https://server.ethicalads.io/api/v1/decision/";
-const AD_CLIENT_VERSION = 1;  // Sent with the ad request
 const AD_TYPES_VERSION = 1;  // Used with the ad type slugs
 const ATTR_PREFIX = "data-ea-";
 const ABP_DETECTION_PX = "https://media.ethicalads.io/abp/px.gif";

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ import "./styles.scss";
 // For local testing, set this
 // const AD_DECISION_URL = "http://ethicaladserver:5000/api/v1/decision/";
 const AD_DECISION_URL = "https://server.ethicalads.io/api/v1/decision/";
-const AD_CLIENT_VERSION = 1;
+const AD_CLIENT_VERSION = 1;  // Sent with the ad request
+const AD_TYPES_VERSION = 1;  // Used with the ad type slugs
 const ATTR_PREFIX = "data-ea-";
 const ABP_DETECTION_PX = "https://media.ethicalads.io/abp/px.gif";
 
@@ -219,7 +220,7 @@ export class Placement {
 
     // Add version to ad type to verison the HTML return
     if (ad_type === "image" || ad_type === "text") {
-      ad_type += "-v" + AD_CLIENT_VERSION;
+      ad_type += "-v" + AD_TYPES_VERSION;
     }
 
     let classes = (element.className || "").split(" ");
@@ -310,6 +311,7 @@ export class Placement {
       keywords: this.keywords.join("|"),
       campaign_types: this.campaign_types.join("|"),
       format: "jsonp",
+      client_version: AD_CLIENT_VERSION,
       // location.href includes query params (possibly sensitive) and fragments (unnecessary)
       url: (window.location.origin + window.location.pathname).slice(0, 256),
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethical-ad-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethical-ad-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "EthicalAds client",
   "main": "dist/client.js",
   "scripts": {


### PR DESCRIPTION
The goal of this is that we can log server side which publishers are using which version of the client. This would be useful if we ever needed to force an update (eg. deprecate/remove old client versions).

In the current implementation, the version is `1` but this could increment rapidly. Arguably we could use a traditional semver type version like `0.1.5` or something like that. A single number is easier for comparison though.