### PR TITLE
Send the ad view time to the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,7 @@ export class Placement {
         // Send the time the ad was viewed to the server
         if (document.visibilityState === "hidden" || document.visibilityState === "unloaded") {
           let pixel = document.createElement("img");
-          pixel.src = placement.response.view_url + "?view_time=" + parseInt(placement.view_time);
+          pixel.src = placement.response.view_url + "?view_time=" + placement.view_time;
           pixel.className = "ea-pixel";
           placement.target.appendChild(pixel);
 

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ export class Placement {
       }, VIEW_TIME_INTERVAL * 1000, placement.target);
 
       document.addEventListener("visibilitychange", () => {
-        // Check if the tab has gone out of focus or the browser/app is minimized
+        // Check if the tab loses focus/is closed or the browser/app is minimized/closed
         // In that case, no longer count further time that the ad is in view
         // Send the time the ad was viewed to the server
         if (document.visibilityState === "hidden" || document.visibilityState === "unloaded") {


### PR DESCRIPTION
The view time is counted in 1 second increments up to a 5 min max. View time is only counted if the ad is in the viewport, the tab is the primary one, and the browser is not minimized. Uses the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) ([supported on IE11](https://caniuse.com/mdn-api_document_visibilitystate))

- Makes an extra request to the ad server when the tab/browser is minimized or about to be closed to send the time the ad was viewed. Any time spent viewing the ad after re-maximizing the browser isn't counted.
- Uses the same "ad view" API but with an extra parameter (**Note**: changes to the ad server will be required to handle this)
- After this change, ad views (even without view time) will require the browser is not minimized and the tab is the primary