### PR TITLE
Tweak around releasing versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /docs/_build/
 .ropeproject/
 *.pyc
-dist/ethicalads-v*.min.js
+ethicalads*.min.js

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -29,7 +29,9 @@ This is the release process for the client itself.
     .. code-block:: bash
 
         # Push this to GitHub and the CDN
-        cp dist/ethicalads.min.js dist/ethicalads-$VERSION.min.js
+        mkdir dist/$VERSION
+        cp dist/ethicalads.min.js dist/$VERSION/
+        cp dist/ethicalads.min.js dist/$VERSION/ethicalads-$VERSION.min.js
 
 * Release the `beta client`_ and purge the client from the CDN.
   A few publishers (notably Read the Docs) use the beta client


### PR DESCRIPTION
We're now storing directories of released versions on our CDN. This more closely matches that process.