### PR TITLE
Decrease the z-index below most modals

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -268,7 +268,7 @@ $color-bg-dark-stickybox: $color-link;
 // https://ethical-ad-client.readthedocs.io/en/latest/#stickybox
 [data-ea-style="stickybox"].loaded {
   .ea-type-image {
-    z-index: 1000;
+    z-index: 10;      // Should be below most modals
     position: fixed;
     bottom: 20px;
     right: 20px;


### PR DESCRIPTION
Bootstrap uses z-indexes above 1000. The RTD search extension uses 500.
There's no standard for z-indexes but this should be below most things that set a z-index.