### PR TITLE
Always treat warnings as warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -703,10 +703,8 @@ if (require.main !== module && check_dependencies()) {
         .catch((err) => {
           resolve([]);
 
-          const is_debug = global.debug || window.debug || false;
-
           if (err instanceof Error) {
-            if (err instanceof EthicalAdsWarning && !is_debug) {
+            if (err instanceof EthicalAdsWarning) {
               // Report these at a lower log level
               console.debug(err.message);
               return;


### PR DESCRIPTION
Chrome seems to define `window.debug` in some situations. Firefox does not. Let's not rely on it at all.

Warnings will be warnings and errors errors for now.