### PR TITLE
Fix duplicated keys in the KEYWORDS dictionary

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,6 @@ const KEYWORDS = {
   "css": "css",
   "scss": "scss",
   "typescript": "typescript",
-  "rust": "rust",
   "redux": "redux",
 
   // Phrases (not currently implemented)


### PR DESCRIPTION
KEYWORDS  dictionary has duplicated keys, this commit removes the duplication