### PR TITLE
Fix the unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
 
 commands:
   run-checks:


### PR DESCRIPTION
Looks like some versions of Chrome are missing ChromeDriver and ChromeDriver is installed based on the Chrome version. The new browser-tools version seems to fix this.